### PR TITLE
Fix 'too many recursions' error

### DIFF
--- a/core/src/main/scala/formula/Fields.scala
+++ b/core/src/main/scala/formula/Fields.scala
@@ -19,7 +19,6 @@ private[formula] object Fields {
     input(
       config.modifiers,
       stringVar.signal.changes.map(parser).collect { case Some(d) => d } --> { value => variable.set(value) },
-      variable.signal.changes.map(_.value.toString) --> stringVar,
       onKeyPress --> { event =>
         if (event.key.length == 1 && !regex.matches(event.key) && !event.metaKey) event.preventDefault()
         touched.set(true)
@@ -105,7 +104,6 @@ private[formula] object Fields {
         },
         input(
           inputConfig.modifiers,
-          var0.signal.map(s => renderMoney(s.value.toString)) --> stringVar,
           value <-- stringVar.signal,
           inContext { el =>
             onInput.mapToValue --> { string =>

--- a/core/src/main/scala/formula/Form.scala
+++ b/core/src/main/scala/formula/Form.scala
@@ -480,14 +480,17 @@ object Form {
       FormValue(var0, node)
     }
 
-  implicit val int: Form[Int] = {
+  implicit val long: Form[Long] = {
     val intRegex = "[0-9]*".r
     Form.Input.make { config =>
       val var0 = config.validate(FormVar.make(0))
-      val node = Fields.regex(config.copy(inputType = "number"), var0, _.toIntOption, intRegex)
+      val node = Fields.regex(config.copy(inputType = "number"), var0, _.toLongOption, intRegex)
       FormValue(var0, node)
     }
   }
+
+  implicit val int: Form[Int] =
+    long.xmap(_.toInt)(_.toLong)
 
   implicit val double: Form[Double] = {
     val doubleRegex: Regex = "-?\\d*\\.?\\d*e?".r
@@ -497,6 +500,9 @@ object Form {
       FormValue(var0, node)
     }
   }
+
+  implicit val float: Form[Float] =
+    double.xmap(_.toFloat)(_.toDouble)
 
   implicit val localDate: Form[LocalDate] =
     Form.Input.make { config =>
@@ -524,5 +530,5 @@ case class FormValue[A](variable: FormVar[A], view: Mod[HtmlElement]) {
 
   def update(f: A => A): Unit = variable.set(variable.get.map(f).value)
 
-  lazy val $value = signal.map(_.value)
+  lazy val $value: Signal[A] = signal.map(_.value)
 }


### PR DESCRIPTION
Probably a regression introduced with #6: Changing an `Int` or `Double` value caused a recursion error.

This PR also introduces `Form`s for `Long` and `Float`, which I was missing.