### PR TITLE
Load `Many` forms properly, fix date fields

### DIFF
--- a/core/src/main/scala/formula/DeriveForm.scala
+++ b/core/src/main/scala/formula/DeriveForm.scala
@@ -51,7 +51,7 @@ object DeriveForm {
 
       // Add validations
       val validations   = param.annotations.collect { case v: validation[_] => v }
-      println(s"${label}: VALIDATIONS ${validations}")
+      //println(s"${label}: VALIDATIONS ${validations}")
       val validatedForm = validations.foldLeft(formWithHelp) { (acc, a) =>
         acc.validate(a.predicate.asInstanceOf[Any => Boolean], a.error)
       }

--- a/core/src/main/scala/formula/Fields.scala
+++ b/core/src/main/scala/formula/Fields.scala
@@ -19,6 +19,7 @@ private[formula] object Fields {
     input(
       config.modifiers,
       stringVar.signal.changes.map(parser).collect { case Some(d) => d } --> { value => variable.set(value) },
+      variable.signal.changes.map(_.value.toString).filterNot(_ == stringVar.now()) --> stringVar,
       onKeyPress --> { event =>
         if (event.key.length == 1 && !regex.matches(event.key) && !event.metaKey) event.preventDefault()
         touched.set(true)
@@ -61,13 +62,13 @@ private[formula] object Fields {
   }
 
   def dateTime(config: InputConfig[LocalDateTime], variable: FormVar[LocalDateTime]): HtmlElement = {
-    val formatter = DateTimeFormatter.ISO_DATE_TIME
+    val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
 
     input(
       config.modifiers,
       `type`("datetime-local"),
       controlled(
-        value <-- variable.signal.map(_.value.format(formatter)),
+        value <-- variable.signal.map(_.value.withSecond(0).withNano(0).format(formatter)),
         onInput.mapToValue --> { text =>
           val result = LocalDateTime.parse(text, formatter)
           variable.set(result)
@@ -104,6 +105,7 @@ private[formula] object Fields {
         },
         input(
           inputConfig.modifiers,
+          var0.signal.changes.map(s => renderMoney(s.value.toString)).filterNot(_ == stringVar.now()) --> stringVar,
           value <-- stringVar.signal,
           inContext { el =>
             onInput.mapToValue --> { string =>


### PR DESCRIPTION
* Fix a regression of `regex` fields where they didn't load the value when `set` was called
* Refrain from using `xmap` since they cause an error on validation, e.g. `Uncaught org.scalajs.linker.runtime.UndefinedBehaviorError: java.lang.ClassCastException: 0 is not an instance of java.lang.Integer`
* Remove debug log
* Fix `dateTime` parsing and setting (required without nano/second)
* Set the `count` field value for `Many` form fields when form value is set
* Add a short delay when loading values for `Many` form fields since `variables.now()` may not be up to date yet after updating the `count` field