### PR TITLE
Properly set values in subforms

### DIFF
--- a/core/src/main/scala/formula/DeriveForm.scala
+++ b/core/src/main/scala/formula/DeriveForm.scala
@@ -51,7 +51,6 @@ object DeriveForm {
 
       // Add validations
       val validations   = param.annotations.collect { case v: validation[_] => v }
-      //println(s"${label}: VALIDATIONS ${validations}")
       val validatedForm = validations.foldLeft(formWithHelp) { (acc, a) =>
         acc.validate(a.predicate.asInstanceOf[Any => Boolean], a.error)
       }

--- a/core/src/main/scala/formula/Form.scala
+++ b/core/src/main/scala/formula/Form.scala
@@ -145,10 +145,10 @@ object Form {
           variables.signal.changes
             .filter(_.length == a.length)
             .take(1)
-            .foreach(_.zip(a).foreach { case (v, a) =>
-              v.set(a)
+            .foreach { v =>
+              v.zip(a).foreach { case (v, a) => v.set(a) }
               owner.killSubscriptions()
-            })
+            }
           countForm.set(a.length)
         }
 


### PR DESCRIPTION
Instead of relying on `setTimeout` which can be flaky for obvious reasons, we now spawn a listener on the updating `Signal` to set the new value on the subform.

The downside here is that an `Owner` must be spawned each time we do this (I'm not sure about the overhead?) but we can can also kill again it each time it's done; hopefully this is enough to prevent leaks.